### PR TITLE
Make stream definitions consistent

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,9 +112,20 @@
       </pre>
 
       <p>
-        <dfn>read()</dfn> This method pulls a chunk of data out of the internal buffer and returns it. If there
-        is no chunk available, then it will return null.
+        A Stream handles a sequence of data as chunks which are emitted or manually pulled over time.
+        The type of the chunks must be consistent.
         Typical types are Buffer or String for serialized data or Quad for RDF data.
+      </p>
+
+      <p>
+        This specification uses the following notation, for a known type <code>T</code> of a Stream:
+        <pre>Stream&lt;T&gt;</pre>
+      </p>
+
+      <p>
+        <dfn>read()</dfn>
+        This method pulls a chunk of data out of the internal buffer and returns it.
+        If there is no chunk available, then it will return null.
       </p>
       <p>
         <dfn>readable</dfn> When a chunk can be read from the stream, it will emit this event.

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 
       <pre class="idl">
       interface Stream : EventEmitter {
-        Quad read();
+        any read();
         attribute Event readable;
         attribute Event end;
         attribute Event error;
@@ -112,20 +112,21 @@
       </pre>
 
       <p>
-        <dfn>read()</dfn> This method pulls a quad out of the internal buffer and returns it. If there
-        is no quad available, then it will return null.
+        <dfn>read()</dfn> This method pulls a chunk of data out of the internal buffer and returns it. If there
+        is no chunk available, then it will return null.
+        Typical types are Buffer or String for serialized data or Quad for RDF data.
       </p>
       <p>
-        <dfn>readable</dfn> When a quad can be read from the stream, it will emit this event.
+        <dfn>readable</dfn> When a chunk can be read from the stream, it will emit this event.
       </p>
       <p>
-        <dfn>end</dfn> This event fires when there will be no more quads to read.
+        <dfn>end</dfn> This event fires when there will be no more chunks to read.
       </p>
       <p>
         <dfn>error</dfn> `error(Error error)` This event fires if any error occurs. The `message` describes the error.
       </p>
       <p>
-        <dfn>data</dfn> `data(Quad quad)` This event is emitted for every quad that can be read from the stream. The `quad` is the content of the data.
+        <dfn>data</dfn> `data(any chunk)` This event is emitted for every chunk that can be read from the stream. The `chunk` is the content of the data.
       </p>
       <h4>Optional Events</h4>
       <p>
@@ -141,7 +142,7 @@
 
       <pre class="idl">
       interface Source {
-        Stream match(optional Term? subject, optional Term? predicate, optional Term? object, optional Term? graph);
+        Stream&lt;Quad&gt; match(optional Term? subject, optional Term? predicate, optional Term? object, optional Term? graph);
       };
       </pre>
 
@@ -193,7 +194,7 @@
 
       <pre class="idl">
       interface Store {
-        EventEmitter remove(Stream stream);
+        EventEmitter remove(Stream&lt;Quad&gt; stream);
         EventEmitter removeMatches(optional Term? subject, optional Term? predicate, optional Term? object, optional Term? graph);
         EventEmitter deleteGraph((Term or string) graph);
       };


### PR DESCRIPTION
This PR should fix #2.

Two remarks:
- In `Typical use cases` we could add more types, but maybe that would be to confusing in the end. `Stream stream` could be `Stream<Buffer or String or Object> stream`. `Buffer` to cover binary formats and encoding specific text formats, `String` for text formats and `Object` for formats which are serialized into JS objects, like JSON-LD.
- `Stream` extends from `EventEmitter`, but that interface is not defined in the spec. Do we want to reference to the [Node.js EventEmitter class](https://nodejs.org/api/events.html#events_class_eventemitter) or define our own interface in the spec? Could be a topic for a different PR.